### PR TITLE
Doc of p,+ macro should mention that it maps to sepBy1, not sepBy

### DIFF
--- a/src/Init/Notation.lean
+++ b/src/Init/Notation.lean
@@ -226,7 +226,7 @@ results. It has arity 1, and auto-groups its component parser if needed.
 -/
 macro:arg x:stx:max ",*"   : stx => `(stx| sepBy($x, ",", ", "))
 /--
-`p,+` is shorthand for `sepBy(p, ",")`. It parses 1 or more occurrences of
+`p,+` is shorthand for `sepBy1(p, ",")`. It parses 1 or more occurrences of
 `p` separated by `,`, that is: `p | p,p | p,p,p | ...`.
 
 It produces a `nullNode` containing a `SepArray` with the interleaved parser


### PR DESCRIPTION
p,+ maps to sepBy1(p, ",") while doc says it maps to sepBy(p, ",").

